### PR TITLE
Fix contact form checkbox styling and CTA link

### DIFF
--- a/src/assets/_custom-overrides.scss
+++ b/src/assets/_custom-overrides.scss
@@ -521,11 +521,21 @@ a {
 
 .contact-form .form-control,
 .contact-form .form-select,
-.contact-form .form-check-input,
 .snapshot-shell .form-control {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--site-border);
   color: var(--site-text);
+}
+
+.contact-form .form-check-input {
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--site-border);
+  color: var(--site-text);
+}
+
+.contact-form .form-check-input:checked {
+  background-color: var(--site-accent);
+  border-color: var(--site-accent);
 }
 
 .contact-form .form-control:focus,

--- a/src/pages/what-we-build.astro
+++ b/src/pages/what-we-build.astro
@@ -70,7 +70,7 @@ const pageCanonical = 'https://digitful.ca/what-we-build/';
           </blockquote>
 
           <div class="mt-4">
-            <a href="/contact/?service=what-we-build" class="btn btn-primary btn-lg px-4">Discuss Your System</a>
+            <a href="/contact/" class="btn btn-primary btn-lg px-4">Discuss Your System</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What changed

This fixes two small contact-flow issues:
- the privacy checkbox now shows its checked state properly
- the What We Build CTA now links to the contact page without a broken service prefill

## Check

- `npm run build` passes
