### PR TITLE
Refine site design system and service accents

### DIFF
--- a/public/scripts/snapshot.js
+++ b/public/scripts/snapshot.js
@@ -37,6 +37,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const perfScore = score(categories.performance);
       const seoScore = score(categories.seo);
       const bestPractices = score(categories['best-practices']);
+      const hostname = (() => {
+        try {
+          return new URL(siteUrl).hostname.replace(/^www\./, '');
+        } catch {
+          return siteUrl;
+        }
+      })();
 
       const grade = (value) =>
         value == null ? '-' : value >= 90 ? 'A' : value >= 75 ? 'B' : value >= 50 ? 'C' : value >= 30 ? 'D' : 'E';
@@ -58,6 +65,11 @@ document.addEventListener('DOMContentLoaded', () => {
       if (bestPractices != null && bestPractices < 90) tips.push('Clean up technical issues that weaken trust and speed.');
       if (!tips.length) tips.push('Strong baseline. The next wins are likely strategic, not technical.');
 
+      const contactUrl = new URL('/contact/', window.location.origin);
+      contactUrl.searchParams.set('source', 'snapshot');
+      contactUrl.searchParams.set('siteUrl', siteUrl);
+      contactUrl.searchParams.set('strategy', strategy);
+
       resultDiv.innerHTML = `
         <div class="card">
           <div class="card-body p-4">
@@ -65,6 +77,8 @@ document.addEventListener('DOMContentLoaded', () => {
               <h3 class="h5 mb-0">Snapshot Results</h3>
               <span class="badge ${barClass(perfScore)}">${strategy === 'mobile' ? 'Mobile' : 'Desktop'}</span>
             </div>
+
+            <p class="text-muted-light mb-4">Initial read for ${hostname}. This is a quick technical pass, not the full growth diagnosis.</p>
 
             ${[
               ['Performance', perfScore],
@@ -96,7 +110,7 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
 
             <div class="mt-4">
-              <a href="/contact/" class="btn btn-outline-light">Get The Full Review</a>
+              <a href="${contactUrl.toString()}" class="btn btn-outline-light">Get The Full Review</a>
             </div>
           </div>
         </div>`;

--- a/public/scripts/toggleButtons.js
+++ b/public/scripts/toggleButtons.js
@@ -1,8 +1,21 @@
 export function initToggleButtons() {
   const toggleButtons = document.querySelectorAll('.toggle-btn');
-  if (toggleButtons.length === 0) return;
-
   const servicesInput = document.getElementById('servicesInput');
+  const sourceInput = document.getElementById('sourceInput');
+  const snapshotUrlInput = document.getElementById('snapshotUrlInput');
+  const snapshotStrategyInput = document.getElementById('snapshotStrategyInput');
+  const messageInput = document.getElementById('message');
+  const params = new URLSearchParams(window.location.search);
+  const serviceLabels = {
+    'social-media': 'Social Media',
+    seo: 'SEO',
+    'paid-ads': 'Paid Ads',
+    automation: 'Automation'
+  };
+
+  if (toggleButtons.length === 0) {
+    return;
+  }
 
   const syncSelectedServices = () => {
     if (!servicesInput) return;
@@ -13,6 +26,10 @@ export function initToggleButtons() {
   };
 
   toggleButtons.forEach((button) => {
+    button.setAttribute('aria-pressed', 'false');
+  });
+
+  toggleButtons.forEach((button) => {
     button.addEventListener('click', function () {
       const isPressed = this.classList.toggle('selected');
       this.setAttribute('aria-pressed', String(isPressed));
@@ -21,13 +38,45 @@ export function initToggleButtons() {
     });
   });
 
-  const serviceParam = new URLSearchParams(window.location.search).get('service');
+  const serviceParam = params.get('service');
   if (serviceParam) {
     const targetButton = document.querySelector(`.toggle-btn[data-service="${serviceParam}"]`);
     if (targetButton) {
       targetButton.classList.add('selected');
       targetButton.setAttribute('aria-pressed', 'true');
     }
+  }
+
+  const sourceParam = params.get('source');
+  const siteUrlParam = params.get('siteUrl');
+  const strategyParam = params.get('strategy');
+
+  if (sourceInput && sourceParam) {
+    sourceInput.value = sourceParam;
+  }
+
+  if (snapshotUrlInput && siteUrlParam) {
+    snapshotUrlInput.value = siteUrlParam;
+  }
+
+  if (snapshotStrategyInput && strategyParam) {
+    snapshotStrategyInput.value = strategyParam;
+  }
+
+  if (messageInput && !messageInput.value && siteUrlParam) {
+    const serviceLine = serviceParam && serviceLabels[serviceParam] ? `Primary focus: ${serviceLabels[serviceParam]}.` : '';
+    const strategyLine = strategyParam ? `Priority view: ${strategyParam}.` : '';
+
+    messageInput.value = [
+      `Website to review: ${siteUrlParam}`,
+      serviceLine,
+      strategyLine,
+      'Current bottleneck:',
+      'What feels unclear or expensive right now:',
+      'What outcome would make this engagement worthwhile:'
+    ]
+      .filter(Boolean)
+      .join('\n');
   }
 
   syncSelectedServices();

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"Digitful","short_name":"Digitful","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#171c24","background_color":"#121821","display":"standalone"}

--- a/src/assets/_custom-overrides.scss
+++ b/src/assets/_custom-overrides.scss
@@ -1,26 +1,42 @@
-@use "sass:color";
-
 :root {
-  --site-bg: #08090a;
-  --site-surface: #13161c;
-  --site-surface-strong: #1a1f29;
-  --site-surface-soft: rgba(255, 255, 255, 0.05);
+  --site-bg: #121821;
+  --site-surface: #19212d;
+  --site-surface-strong: #222c3a;
+  --site-surface-soft: rgba(255, 255, 255, 0.06);
   --site-text: #f5f7fb;
-  --site-text-muted: #a7afc0;
-  --site-text-dim: #7d8393;
-  --site-border: rgba(255, 255, 255, 0.08);
-  --site-border-subtle: rgba(255, 255, 255, 0.05);
+  --site-text-muted: #afbacb;
+  --site-text-dim: #8792a5;
+  --site-border: rgba(202, 215, 235, 0.18);
+  --site-border-subtle: rgba(202, 215, 235, 0.1);
   --site-accent: #5e6ad2;
-  --site-accent-bright: #737ef0;
-  --site-accent-soft: #97a3ff;
-  --site-accent-mint: #62d5c8;
-  --site-accent-rose: #e28fb0;
-  --site-glow: rgba(94, 106, 210, 0.2);
+  --site-accent-bright: #7b88f2;
+  --site-accent-soft: #a8b2ff;
+  --site-glow: rgba(94, 106, 210, 0.18);
   --site-success: #10b981;
   --site-radius: 18px;
   --site-radius-sm: 12px;
-  --site-shadow: 0 24px 80px rgba(0, 0, 0, 0.34);
-  --site-shadow-soft: 0 16px 48px rgba(0, 0, 0, 0.22);
+  --site-shadow: 0 24px 70px rgba(3, 8, 18, 0.32);
+  --site-shadow-soft: 0 14px 36px rgba(3, 8, 18, 0.2);
+
+  --accent-social: #c86b8d;
+  --accent-social-soft: rgba(200, 107, 141, 0.14);
+  --accent-social-border: rgba(200, 107, 141, 0.3);
+  --accent-social-glow: rgba(200, 107, 141, 0.22);
+
+  --accent-seo: #2fae92;
+  --accent-seo-soft: rgba(47, 174, 146, 0.14);
+  --accent-seo-border: rgba(47, 174, 146, 0.3);
+  --accent-seo-glow: rgba(47, 174, 146, 0.22);
+
+  --accent-paid: #d69a34;
+  --accent-paid-soft: rgba(214, 154, 52, 0.15);
+  --accent-paid-border: rgba(214, 154, 52, 0.32);
+  --accent-paid-glow: rgba(214, 154, 52, 0.22);
+
+  --accent-automation: #5e8cff;
+  --accent-automation-soft: rgba(94, 140, 255, 0.14);
+  --accent-automation-border: rgba(94, 140, 255, 0.3);
+  --accent-automation-glow: rgba(94, 140, 255, 0.22);
 }
 
 html {
@@ -29,10 +45,9 @@ html {
 
 body {
   background:
-    radial-gradient(circle at top left, rgba(94, 106, 210, 0.18), transparent 32%),
-    radial-gradient(circle at 86% 18%, rgba(98, 213, 200, 0.12), transparent 22%),
-    radial-gradient(circle at 20% 72%, rgba(226, 143, 176, 0.08), transparent 18%),
-    linear-gradient(180deg, #08090a 0%, #0d1117 100%);
+    radial-gradient(circle at top left, rgba(123, 136, 242, 0.14), transparent 34%),
+    radial-gradient(circle at 82% 20%, rgba(94, 106, 210, 0.08), transparent 24%),
+    linear-gradient(180deg, #18202b 0%, #151c26 48%, #121821 100%);
   color: var(--site-text);
   font-feature-settings: "cv01", "ss03";
   letter-spacing: -0.01em;
@@ -45,6 +60,15 @@ main {
 
 a {
   transition: color 0.2s ease, opacity 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid rgba(123, 136, 242, 0.7);
+  outline-offset: 3px;
 }
 
 .site-shell {
@@ -67,7 +91,7 @@ a {
   left: -4rem;
   width: 24rem;
   height: 24rem;
-  background: rgba(94, 106, 210, 0.2);
+  background: rgba(123, 136, 242, 0.16);
 }
 
 .page-glow--two {
@@ -75,7 +99,7 @@ a {
   right: -8rem;
   width: 26rem;
   height: 26rem;
-  background: rgba(98, 213, 200, 0.12);
+  background: rgba(94, 106, 210, 0.1);
 }
 
 .page-glow--three {
@@ -83,7 +107,7 @@ a {
   left: 20%;
   width: 18rem;
   height: 18rem;
-  background: rgba(226, 143, 176, 0.08);
+  background: rgba(123, 136, 242, 0.08);
 }
 
 .site-header {
@@ -91,7 +115,7 @@ a {
   top: 0;
   z-index: 20;
   backdrop-filter: blur(18px);
-  background: rgba(8, 9, 10, 0.72);
+  background: rgba(18, 24, 33, 0.78);
   border-bottom: 1px solid var(--site-border-subtle);
 }
 
@@ -123,7 +147,7 @@ a {
 }
 
 .dropdown-menu-dark {
-  background: rgba(17, 18, 21, 0.96);
+  background: rgba(24, 31, 42, 0.98);
   border: 1px solid var(--site-border);
   border-radius: 14px;
   box-shadow: var(--site-shadow-soft);
@@ -154,23 +178,23 @@ a {
 }
 
 .btn-primary {
-  background: linear-gradient(180deg, var(--site-accent-bright), var(--site-accent));
-  border-color: transparent;
+  background: var(--site-accent);
+  border-color: rgba(168, 178, 255, 0.28);
   color: #fff;
-  box-shadow: 0 14px 34px rgba(94, 106, 210, 0.26);
+  box-shadow: 0 10px 24px rgba(94, 106, 210, 0.2);
 }
 
 .btn-primary:hover,
 .btn-primary:focus {
-  background: linear-gradient(180deg, #8290ff, var(--site-accent-bright));
-  border-color: transparent;
+  background: var(--site-accent-bright);
+  border-color: rgba(168, 178, 255, 0.4);
   color: #fff;
-  box-shadow: 0 18px 40px rgba(94, 106, 210, 0.3);
+  box-shadow: 0 14px 30px rgba(94, 106, 210, 0.24);
 }
 
 .btn-outline-light {
-  background: rgba(151, 163, 255, 0.08);
-  border-color: rgba(151, 163, 255, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  border-color: rgba(202, 215, 235, 0.18);
   color: var(--site-text);
 }
 
@@ -182,14 +206,14 @@ a {
 }
 
 .btn-ghost {
-  background: rgba(98, 213, 200, 0.06);
-  border: 1px solid rgba(98, 213, 200, 0.16);
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(202, 215, 235, 0.14);
   color: var(--site-text);
 }
 
 .btn-ghost:hover,
 .btn-ghost:focus {
-  background: rgba(98, 213, 200, 0.12);
+  background: rgba(255, 255, 255, 0.06);
   color: var(--site-text);
 }
 
@@ -274,8 +298,8 @@ a {
 .card,
 .service-item {
   background:
-    linear-gradient(180deg, rgba(151, 163, 255, 0.05), rgba(255, 255, 255, 0.02)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.025)),
+    var(--site-surface);
   border: 1px solid var(--site-border);
   border-radius: var(--site-radius);
   box-shadow: var(--site-shadow-soft);
@@ -310,8 +334,12 @@ a {
 .snapshot-shell,
 .story-card,
 .contact-card,
-.footer-panel {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.025));
+.footer-panel,
+.detail-card,
+.fit-card,
+.expectation-card,
+.proof-note {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.025));
   border: 1px solid var(--site-border-subtle);
   border-radius: var(--site-radius-sm);
 }
@@ -321,7 +349,11 @@ a {
 .service-card,
 .process-step,
 .story-card,
-.contact-card {
+.contact-card,
+.detail-card,
+.fit-card,
+.expectation-card,
+.proof-note {
   padding: 1rem 1.05rem;
 }
 
@@ -376,7 +408,8 @@ a {
 .service-card-grid,
 .process-grid,
 .story-grid,
-.contact-grid {
+.contact-grid,
+.detail-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
@@ -389,6 +422,18 @@ a {
   flex-direction: column;
   gap: 0.8rem;
   height: 100%;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.service-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--card-accent-border, rgba(168, 178, 255, 0.28)), transparent);
+  pointer-events: none;
 }
 
 .service-card__icon,
@@ -400,21 +445,9 @@ a {
   align-items: center;
   justify-content: center;
   border-radius: 12px;
-  background: linear-gradient(135deg, rgba(94, 106, 210, 0.22), rgba(98, 213, 200, 0.14));
-  color: #dbe1ff;
+  background: linear-gradient(135deg, rgba(123, 136, 242, 0.2), rgba(94, 106, 210, 0.1));
+  color: #e1e6ff;
   font-size: 1.25rem;
-}
-
-.service-card:nth-child(2) .service-card__icon,
-.story-card:nth-child(2) .story-card__icon,
-.contact-card:nth-child(2) .contact-card__icon {
-  background: linear-gradient(135deg, rgba(98, 213, 200, 0.22), rgba(94, 106, 210, 0.14));
-}
-
-.service-card:nth-child(3) .service-card__icon,
-.story-card:nth-child(3) .story-card__icon,
-.contact-card:nth-child(3) .contact-card__icon {
-  background: linear-gradient(135deg, rgba(226, 143, 176, 0.2), rgba(94, 106, 210, 0.12));
 }
 
 .service-card__meta {
@@ -432,6 +465,47 @@ a {
 
 .service-card__link:hover {
   color: var(--site-text);
+  transform: translateY(-2px);
+  border-color: var(--card-accent-border, var(--site-border));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.03));
+}
+
+.service-card--social {
+  --card-accent: var(--accent-social);
+  --card-accent-soft: var(--accent-social-soft);
+  --card-accent-border: var(--accent-social-border);
+  --card-accent-glow: var(--accent-social-glow);
+}
+
+.service-card--seo {
+  --card-accent: var(--accent-seo);
+  --card-accent-soft: var(--accent-seo-soft);
+  --card-accent-border: var(--accent-seo-border);
+  --card-accent-glow: var(--accent-seo-glow);
+}
+
+.service-card--paid {
+  --card-accent: var(--accent-paid);
+  --card-accent-soft: var(--accent-paid-soft);
+  --card-accent-border: var(--accent-paid-border);
+  --card-accent-glow: var(--accent-paid-glow);
+}
+
+.service-card--automation {
+  --card-accent: var(--accent-automation);
+  --card-accent-soft: var(--accent-automation-soft);
+  --card-accent-border: var(--accent-automation-border);
+  --card-accent-glow: var(--accent-automation-glow);
+}
+
+.service-card--social .service-card__icon,
+.service-card--seo .service-card__icon,
+.service-card--paid .service-card__icon,
+.service-card--automation .service-card__icon {
+  background: linear-gradient(135deg, var(--card-accent-soft), rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--card-accent-border);
+  box-shadow: 0 10px 20px var(--card-accent-glow);
+  color: var(--card-accent);
 }
 
 .process-step {
@@ -445,11 +519,85 @@ a {
   align-items: center;
   justify-content: center;
   border-radius: 999px;
-  background: rgba(94, 106, 210, 0.18);
-  color: #dce2ff;
+  background: rgba(94, 106, 210, 0.16);
+  color: #e6eaff;
   font-size: 0.9rem;
   font-weight: 700;
   margin-bottom: 0.8rem;
+}
+
+.page-theme {
+  --page-accent: var(--site-accent);
+  --page-accent-soft: rgba(94, 106, 210, 0.12);
+  --page-accent-border: rgba(94, 106, 210, 0.28);
+  --page-accent-glow: rgba(94, 106, 210, 0.22);
+}
+
+.page-theme--social {
+  --page-accent: var(--accent-social);
+  --page-accent-soft: var(--accent-social-soft);
+  --page-accent-border: var(--accent-social-border);
+  --page-accent-glow: var(--accent-social-glow);
+}
+
+.page-theme--seo {
+  --page-accent: var(--accent-seo);
+  --page-accent-soft: var(--accent-seo-soft);
+  --page-accent-border: var(--accent-seo-border);
+  --page-accent-glow: var(--accent-seo-glow);
+}
+
+.page-theme--paid {
+  --page-accent: var(--accent-paid);
+  --page-accent-soft: var(--accent-paid-soft);
+  --page-accent-border: var(--accent-paid-border);
+  --page-accent-glow: var(--accent-paid-glow);
+}
+
+.page-theme--automation {
+  --page-accent: var(--accent-automation);
+  --page-accent-soft: var(--accent-automation-soft);
+  --page-accent-border: var(--accent-automation-border);
+  --page-accent-glow: var(--accent-automation-glow);
+}
+
+.page-theme .eyebrow::before {
+  background: var(--page-accent);
+  box-shadow: 0 0 16px var(--page-accent-glow);
+}
+
+.page-theme .service-shell {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top right, var(--page-accent-soft), transparent 26%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.025));
+  border-color: var(--page-accent-border);
+}
+
+.page-theme .service-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--page-accent-border), transparent);
+  pointer-events: none;
+}
+
+.page-theme .process-step__number {
+  background: var(--page-accent-soft);
+  color: var(--page-accent);
+}
+
+.page-theme .btn-primary {
+  border-color: var(--page-accent-border);
+  box-shadow: 0 10px 24px var(--page-accent-glow);
+}
+
+.page-theme .btn-primary:hover,
+.page-theme .btn-primary:focus {
+  border-color: var(--page-accent-border);
+  box-shadow: 0 14px 28px var(--page-accent-glow);
 }
 
 .service-hero,
@@ -487,7 +635,7 @@ a {
   position: absolute;
   inset: 0 0 auto 0;
   height: 1px;
-  background: linear-gradient(90deg, rgba(151, 163, 255, 0), rgba(151, 163, 255, 0.5), rgba(98, 213, 200, 0.45), rgba(151, 163, 255, 0));
+  background: linear-gradient(90deg, rgba(168, 178, 255, 0), rgba(168, 178, 255, 0.35), rgba(168, 178, 255, 0));
   pointer-events: none;
 }
 
@@ -512,8 +660,8 @@ a {
   max-width: 56rem;
   margin: 0 auto;
   background:
-    radial-gradient(circle at top right, rgba(98, 213, 200, 0.08), transparent 24%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.025));
+    radial-gradient(circle at top right, rgba(123, 136, 242, 0.09), transparent 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.065), rgba(255, 255, 255, 0.03));
   border: 1px solid var(--site-border);
   border-radius: var(--site-radius);
   box-shadow: var(--site-shadow-soft);
@@ -562,8 +710,8 @@ a {
 .snapshot-shell {
   border: 1px solid var(--site-border);
   background:
-    radial-gradient(circle at top right, rgba(98, 213, 200, 0.07), transparent 24%),
-    linear-gradient(180deg, rgba(17, 18, 21, 0.9), rgba(11, 12, 14, 0.96));
+    radial-gradient(circle at top right, rgba(123, 136, 242, 0.08), transparent 24%),
+    linear-gradient(180deg, rgba(25, 33, 45, 0.94), rgba(18, 24, 33, 0.98));
 }
 
 .snapshot-shell .progress {
@@ -598,12 +746,99 @@ a {
   padding-left: 1.1rem;
 }
 
+.category-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.38rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--category-accent-border, var(--site-border));
+  background: var(--category-accent-soft, rgba(255, 255, 255, 0.04));
+  color: var(--category-accent, var(--site-text));
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.category-chip::before {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+  background: var(--category-accent, var(--site-accent));
+}
+
+.category-chip--social {
+  --category-accent: var(--accent-social);
+  --category-accent-soft: var(--accent-social-soft);
+  --category-accent-border: var(--accent-social-border);
+}
+
+.category-chip--seo {
+  --category-accent: var(--accent-seo);
+  --category-accent-soft: var(--accent-seo-soft);
+  --category-accent-border: var(--accent-seo-border);
+}
+
+.category-chip--paid {
+  --category-accent: var(--accent-paid);
+  --category-accent-soft: var(--accent-paid-soft);
+  --category-accent-border: var(--accent-paid-border);
+}
+
+.category-chip--automation {
+  --category-accent: var(--accent-automation);
+  --category-accent-soft: var(--accent-automation-soft);
+  --category-accent-border: var(--accent-automation-border);
+}
+
 .site-footer {
   position: relative;
   z-index: 1;
   padding-top: 0.65rem;
   padding-bottom: 1rem;
   border-top: 1px solid var(--site-border-subtle);
+}
+
+.detail-card strong,
+.fit-card strong,
+.expectation-card strong {
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.detail-card p,
+.fit-card p,
+.expectation-card p,
+.fit-card li,
+.detail-card li,
+.expectation-card li {
+  color: var(--site-text-muted);
+}
+
+.detail-grid,
+.fit-grid,
+.expectation-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.fit-grid,
+.expectation-grid {
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.detail-card ul,
+.fit-card ul,
+.expectation-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.detail-card li + li,
+.fit-card li + li,
+.expectation-card li + li {
+  margin-top: 0.45rem;
 }
 
 .footer-panel {
@@ -714,7 +949,8 @@ blockquote {
   .service-card-grid,
   .process-grid,
   .story-grid,
-  .contact-grid {
+  .contact-grid,
+  .detail-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -755,11 +991,13 @@ blockquote {
   .proof-grid,
   .snapshot-grid,
   .service-grid,
-  .proof-grid,
   .service-card-grid,
   .process-grid,
   .story-grid,
-  .contact-grid {
+  .contact-grid,
+  .detail-grid,
+  .fit-grid,
+  .expectation-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/assets/_custom-overrides.scss
+++ b/src/assets/_custom-overrides.scss
@@ -521,11 +521,21 @@ a {
 
 .contact-form .form-control,
 .contact-form .form-select,
-.contact-form .form-check-input,
 .snapshot-shell .form-control {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--site-border);
   color: var(--site-text);
+}
+
+.contact-form .form-check-input {
+  background-color: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--site-border);
+  color: var(--site-text);
+}
+
+.contact-form .form-check-input:checked {
+  background-color: var(--site-accent);
+  border-color: var(--site-accent);
 }
 
 .contact-form .form-control:focus,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,16 +5,54 @@ import '../assets/bootstrap.scss';
 import 'bootstrap-icons/font/bootstrap-icons.css';
 
 const { title, description, canonicalUrl } = Astro.props;
+const siteName = 'Digitful';
+const themeColor = '#171c24';
+const organizationSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: siteName,
+  url: 'https://digitful.ca/',
+  email: 'ping@digitful.ca',
+  telephone: '+1-579-779-7779',
+  areaServed: 'CA',
+  contactPoint: [
+    {
+      '@type': 'ContactPoint',
+      contactType: 'sales',
+      email: 'ping@digitful.ca',
+      telephone: '+1-579-779-7779',
+      availableLanguage: ['English']
+    }
+  ]
+};
+const websiteSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: siteName,
+  url: 'https://digitful.ca/'
+};
 ---
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-CA">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <meta name="robots" content="index,follow" />
+    <meta name="theme-color" content={themeColor} />
     <link rel="canonical" href={canonicalUrl} />
+    <link rel="manifest" href="/site.webmanifest" />
     <title>{title}</title>
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_CA" />
+    <meta property="og:site_name" content={siteName} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -22,6 +60,8 @@ const { title, description, canonicalUrl } = Astro.props;
       rel="stylesheet"
     />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script type="application/ld+json" set:html={JSON.stringify(organizationSchema)}></script>
+    <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)}></script>
     <script is:inline>
       (function (w, d, s, l, i) {
         w[l] = w[l] || [];

--- a/src/pages/automation.astro
+++ b/src/pages/automation.astro
@@ -7,7 +7,7 @@ const pageCanonical = 'https://digitful.ca/automation/';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription} canonicalUrl={pageCanonical}>
-  <main>
+  <main class="page-theme page-theme--automation">
     <section class="service-hero text-center">
       <div class="container">
         <span class="eyebrow mb-3">Process automation</span>
@@ -27,10 +27,6 @@ const pageCanonical = 'https://digitful.ca/automation/';
             <li>Your team is losing time to repetitive tasks that should already be systemized.</li>
             <li>The tools exist, but the workflow between them is weak or manual.</li>
           </ul>
-
-          <p class="service-copy">
-            We build automation around business flow, ownership, and trust.
-          </p>
 
           <div class="process-grid mt-4">
             <div class="process-step">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -24,7 +24,7 @@ const pageCanonical = 'https://digitful.ca/contact/';
           <div class="section-intro">
             <h2 class="mb-3">Start the conversation</h2>
             <p class="contact-form__intro mb-0">
-              A little context helps.
+              Share what is working, what is unclear, and what needs attention.
             </p>
           </div>
 
@@ -68,6 +68,9 @@ const pageCanonical = 'https://digitful.ca/contact/';
               </div>
               <input type="hidden" name="_next" value="https://digitful.ca/thank-you/" />
               <input type="hidden" name="_captcha" value="false" />
+              <input type="hidden" name="source" id="sourceInput" />
+              <input type="hidden" name="snapshot_url" id="snapshotUrlInput" />
+              <input type="hidden" name="snapshot_strategy" id="snapshotStrategyInput" />
               <input type="text" name="_honey" style="display:none" />
               <div class="col-12">
                 <div class="form-floating">
@@ -95,6 +98,8 @@ const pageCanonical = 'https://digitful.ca/contact/';
               </div>
             </div>
           </form>
+
+          <p class="text-muted-light small mb-0 mt-4">We reply within 1 to 2 business days.</p>
         </div>
       </div>
     </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,28 +33,25 @@ const pageCanonical = 'https://digitful.ca/';
     <section class="py-6">
       <div class="container">
         <div class="section-intro">
-          <span class="eyebrow mb-3">Why teams call us</span>
+          <span class="eyebrow mb-3">What we fix</span>
           <h2 class="mb-3">More traffic will not fix a broken system.</h2>
           <p class="mb-0">
-            If the message, funnel, or follow-up is weak, growth stays expensive.
+            Weak message, messy conversion paths, and slow follow-up keep growth expensive.
           </p>
         </div>
 
-        <div class="proof-grid">
-          <div class="metric-card">
-            <span class="metric-card__value">1</span>
-            <strong>Shared priorities</strong>
-            <span>Strategy, execution, and reporting aligned.</span>
+        <div class="detail-grid">
+          <div class="detail-card">
+            <strong>Weak message</strong>
+            <p class="mb-0">If the offer is unclear, everything downstream gets harder.</p>
           </div>
-          <div class="metric-card">
-            <span class="metric-card__value">2</span>
-            <strong>Better-fit demand</strong>
-            <span>Acquisition built for the right buyer.</span>
+          <div class="detail-card">
+            <strong>Leaky conversion path</strong>
+            <p class="mb-0">Traffic does not help much when the next step feels vague.</p>
           </div>
-          <div class="metric-card">
-            <span class="metric-card__value">3</span>
-            <strong>Faster follow-through</strong>
-            <span>Automation that keeps leads moving.</span>
+          <div class="detail-card">
+            <strong>Slow follow-up</strong>
+            <p class="mb-0">Manual handoffs create lag, missed leads, and wasted energy.</p>
           </div>
         </div>
       </div>
@@ -71,7 +68,7 @@ const pageCanonical = 'https://digitful.ca/';
         </div>
 
         <div class="service-card-grid service-card-grid--offers">
-          <a href="/social-media/" class="service-card service-card__link">
+          <a href="/social-media/" class="service-card service-card__link service-card--social">
             <span class="service-card__icon"><i class="bi bi-chat-square-text"></i></span>
             <div>
               <h3>Social Media</h3>
@@ -79,7 +76,7 @@ const pageCanonical = 'https://digitful.ca/';
             </div>
           </a>
 
-          <a href="/seo/" class="service-card service-card__link">
+          <a href="/seo/" class="service-card service-card__link service-card--seo">
             <span class="service-card__icon"><i class="bi bi-search"></i></span>
             <div>
               <h3>SEO</h3>
@@ -87,7 +84,7 @@ const pageCanonical = 'https://digitful.ca/';
             </div>
           </a>
 
-          <a href="/paid-ads/" class="service-card service-card__link">
+          <a href="/paid-ads/" class="service-card service-card__link service-card--paid">
             <span class="service-card__icon"><i class="bi bi-bullseye"></i></span>
             <div>
               <h3>Paid Ads</h3>
@@ -95,7 +92,7 @@ const pageCanonical = 'https://digitful.ca/';
             </div>
           </a>
 
-          <a href="/automation/" class="service-card service-card__link">
+          <a href="/automation/" class="service-card service-card__link service-card--automation">
             <span class="service-card__icon"><i class="bi bi-diagram-3"></i></span>
             <div>
               <h3>Process Automation</h3>
@@ -109,58 +106,28 @@ const pageCanonical = 'https://digitful.ca/';
     <section class="py-6">
       <div class="container">
         <div class="section-intro">
-          <span class="eyebrow mb-3">How we work</span>
-          <h2 class="mb-3">We build the system before we try to scale it.</h2>
-          <p class="mb-0">
-            Diagnose the constraint, build the system, then scale what works.
-          </p>
-        </div>
-
-        <div class="process-grid">
-          <div class="process-step">
-            <span class="process-step__number">01</span>
-            <strong>Diagnose</strong>
-            <p>We find the real bottleneck.</p>
-          </div>
-          <div class="process-step">
-            <span class="process-step__number">02</span>
-            <strong>Build</strong>
-            <p>We tighten the offer, funnel, and workflow.</p>
-          </div>
-          <div class="process-step">
-            <span class="process-step__number">03</span>
-            <strong>Scale</strong>
-            <p>We scale what proves itself.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="py-6">
-      <div class="container">
-        <div class="section-intro">
           <span class="eyebrow mb-3">Good fit</span>
           <h2 class="mb-3">A good fit for teams that need more clarity.</h2>
           <p class="mb-0">
-            Best for teams with momentum and operational drag.
+            Best for businesses with momentum and operational drag.
           </p>
         </div>
 
         <div class="story-grid">
           <div class="story-card">
             <span class="story-card__icon"><i class="bi bi-rocket-takeoff"></i></span>
-            <strong>You are growing</strong>
-            <p>Demand exists, but follow-through is uneven.</p>
+            <strong>You already have demand</strong>
+            <p>Interest exists, but the system around it is uneven.</p>
           </div>
           <div class="story-card">
             <span class="story-card__icon"><i class="bi bi-graph-up-arrow"></i></span>
-            <strong>You need signal</strong>
-            <p>You want a few real indicators, not more dashboards.</p>
+            <strong>You need clearer priorities</strong>
+            <p>You want signal, not more moving parts.</p>
           </div>
           <div class="story-card">
             <span class="story-card__icon"><i class="bi bi-lightning-charge"></i></span>
-            <strong>You need leverage</strong>
-            <p>You want systems that make the team faster.</p>
+            <strong>You want systems your team can run</strong>
+            <p>You need fewer manual gaps and cleaner follow-through.</p>
           </div>
         </div>
       </div>

--- a/src/pages/paid-ads.astro
+++ b/src/pages/paid-ads.astro
@@ -7,7 +7,7 @@ const pageCanonical = 'https://digitful.ca/paid-ads/';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription} canonicalUrl={pageCanonical}>
-  <main>
+  <main class="page-theme page-theme--paid">
     <section class="service-hero text-center">
       <div class="container">
         <span class="eyebrow mb-3">Paid ads</span>
@@ -27,10 +27,6 @@ const pageCanonical = 'https://digitful.ca/paid-ads/';
             <li>Targeting is broad because the offer and audience are still blurry.</li>
             <li>Spend keeps rising while confidence in the channel keeps falling.</li>
           </ul>
-
-          <p class="service-copy">
-            We build paid systems around message clarity, audience fit, and conversion.
-          </p>
 
           <div class="process-grid mt-4">
             <div class="process-step">

--- a/src/pages/seo.astro
+++ b/src/pages/seo.astro
@@ -7,7 +7,7 @@ const pageCanonical = 'https://digitful.ca/seo/';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription} canonicalUrl={pageCanonical}>
-  <main>
+  <main class="page-theme page-theme--seo">
     <section class="service-hero text-center">
       <div class="container">
         <span class="eyebrow mb-3">SEO</span>
@@ -27,10 +27,6 @@ const pageCanonical = 'https://digitful.ca/seo/';
             <li>Traffic arrives, but the next step is confusing or weak.</li>
             <li>Reports look active, but the business impact is still missing.</li>
           </ul>
-
-          <p class="service-copy">
-            We focus on the SEO work that changes outcomes: structure, intent, and conversion.
-          </p>
 
           <div class="process-grid mt-4">
             <div class="process-step">

--- a/src/pages/social-media.astro
+++ b/src/pages/social-media.astro
@@ -7,7 +7,7 @@ const pageCanonical = 'https://digitful.ca/social-media/';
 ---
 
 <BaseLayout title={pageTitle} description={pageDescription} canonicalUrl={pageCanonical}>
-  <main>
+  <main class="page-theme page-theme--social">
     <section class="service-hero text-center">
       <div class="container">
         <span class="eyebrow mb-3">Social media</span>
@@ -27,10 +27,6 @@ const pageCanonical = 'https://digitful.ca/social-media/';
             <li>Content feels random because the positioning underneath it is weak.</li>
             <li>The team is spending energy on channels that are not helping buyers decide.</li>
           </ul>
-
-          <p class="service-copy">
-            We build social systems around message, relevance, and conversion.
-          </p>
 
           <div class="process-grid mt-4">
             <div class="process-step">

--- a/src/pages/what-we-build.astro
+++ b/src/pages/what-we-build.astro
@@ -70,7 +70,7 @@ const pageCanonical = 'https://digitful.ca/what-we-build/';
           </blockquote>
 
           <div class="mt-4">
-            <a href="/contact/?service=what-we-build" class="btn btn-primary btn-lg px-4">Discuss Your System</a>
+            <a href="/contact/" class="btn btn-primary btn-lg px-4">Discuss Your System</a>
           </div>
         </div>
       </div>

--- a/src/pages/what-we-build.astro
+++ b/src/pages/what-we-build.astro
@@ -65,10 +65,6 @@ const pageCanonical = 'https://digitful.ca/what-we-build/';
             </div>
           </div>
 
-          <blockquote class="mt-4">
-            <p class="mb-0">The goal is a system the business can trust and scale.</p>
-          </blockquote>
-
           <div class="mt-4">
             <a href="/contact/" class="btn btn-primary btn-lg px-4">Discuss Your System</a>
           </div>


### PR DESCRIPTION
## Summary

This refreshes the site design system and tightens the page structure.

Changes include:
- lighter charcoal surfaces and cleaner contrast
- restrained accent colors for the 4 service categories
- simpler homepage and service-page copy
- cleaner contact flow with service preselection preserved
- improved shared metadata and manifest details

## Why

The goal was to make the site feel sharper, easier to scan, and more visually distinct without losing the stripped-down feel.

## Validation

- `npm run build`

## Notes

Bootstrap Sass deprecation warnings still appear during build and were already present before this PR.
